### PR TITLE
Content Menu Colours

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -39,6 +39,11 @@ const config = {
       x: 7,
       y: 5,
     },
+    color: {
+      item: '#ffaa00',
+      npc: '#f9f920',
+      player: '#ffffff',
+    },
   },
 };
 

--- a/src/core/player/actions.js
+++ b/src/core/player/actions.js
@@ -23,18 +23,18 @@ class Actions {
       x: (this.player.x - map.player.x) + this.clicked.x,
       y: (this.player.y - map.player.y) + this.clicked.y,
     };
-    for (let i = 0; i < this.npcs.length; i += 1) {
-      if (this.npcs[i].x === this.coordinates.x) {
-        if (this.npcs[i].y === this.coordinates.y) {
-          console.log(config.map.color.npc);
-          this.color = config.map.color.npc;
+    // These two 'for' loops are used to find any npcs or items at the
+    // mouse click location and set the color accordingly.
+    for (let i = 0; i < this.npcs.length; i += 1) { // Scans through NPCs
+      if (this.npcs[i].x === this.coordinates.x) { // Checks to see if NPCs
+        if (this.npcs[i].y === this.coordinates.y) { // match X and Y coords
+          this.color = config.map.color.npc; // Sets the color accordingly
         }
       }
     }
     for (let i = 0; i < this.droppedItems.length; i += 1) {
       if (this.droppedItems[i].x === this.coordinates.x) {
         if (this.droppedItems[i].y === this.coordinates.y) {
-          console.log(config.map.color.item);
           this.color = config.map.color.item;
         }
       }

--- a/src/core/player/actions.js
+++ b/src/core/player/actions.js
@@ -1,6 +1,10 @@
 import bus from '../utilities/bus';
+
 import UI from '../utilities/ui';
+
 import { map } from '../config';
+
+const config = require('../config');
 
 class Actions {
   constructor(data, tile) {
@@ -8,7 +12,6 @@ class Actions {
     this.background = data.background;
     this.npcs = data.npcs;
     this.droppedItems = data.map.droppedItems;
-
     // Viewport X,Y coordinates
     this.clicked = {
       x: tile.x,
@@ -20,12 +23,24 @@ class Actions {
       x: (this.player.x - map.player.x) + this.clicked.x,
       y: (this.player.y - map.player.y) + this.clicked.y,
     };
+    for (let i = 0; i < this.npcs.length; i += 1) {
+      if (this.npcs[i].x === this.coordinates.x) {
+        if (this.npcs[i].y === this.coordinates.y) {
+          console.log(config.map.color.npc);
+          this.color = config.map.color.npc;
+        }
+      }
+    }
+    for (let i = 0; i < this.droppedItems.length; i += 1) {
+      if (this.droppedItems[i].x === this.coordinates.x) {
+        if (this.droppedItems[i].y === this.coordinates.y) {
+          console.log(config.map.color.item);
+          this.color = config.map.color.item;
+        }
+      }
+    }
 
     // Label color
-    this.color = {
-      Examine: '#EBE04D',
-      Take: '#ffa619',
-    };
   }
 
   /**
@@ -89,7 +104,6 @@ class Actions {
         break;
     }
   }
-
   /**
    * Build the context-menu list items
    */
@@ -134,7 +148,7 @@ class Actions {
 
           if (itemData.actions.includes(action.toLowerCase())) {
             const object = {
-              label: `${action} <span style='color:${this.color[action]}'>${itemData.name}</span>`,
+              label: `${action} <span style='color:${this.color}'>${itemData.name}</span>`,
               action,
               type: 'item',
               id: itemData.id,
@@ -151,7 +165,7 @@ class Actions {
         getNPCs.forEach((npc) => {
           if (npc.actions.includes(action.toLowerCase())) {
             const object = {
-              label: `${action} <span style='color:${this.color[action]}'>${npc.name}</span>`,
+              label: `${action} <span style='color:${this.color}'>${npc.name}</span>`,
               action,
               type: 'npc',
               id: npc.id,
@@ -166,7 +180,7 @@ class Actions {
 
           if (itemData.actions.includes(action.toLowerCase())) {
             const object = {
-              label: `Examine <span style='color:${this.color[action]}'>${itemData.name}</span>`,
+              label: `Examine <span style='color:${this.color}'>${itemData.name}</span>`,
               action,
               type: 'item',
               id: itemData.id,


### PR DESCRIPTION
# Description
This patch creates two **for** loops that search through all the NPCs and Items on the map. If one is clicked then the colour of the context menu is changed to support this in action.js.

In config.js the colour of the options can be set.
# Related Issue
This was patch was made to resolve issue #17.
# Motivation and Context
Motivation was created by #17. I see that it completely resolves the issue.
# How Has This Been Tested?
Checking all NPCs and Items available to click as well as checking pre-patch functionality with post-patch to ensure that no errors were made and nothing important was accidentally removed.
# Screenshots (if appropriate):
![context-old](https://user-images.githubusercontent.com/22051776/36477361-d03fdd3a-173b-11e8-8980-b7b6aa05f24a.png)
![context-new](https://user-images.githubusercontent.com/22051776/36477372-d69d8128-173b-11e8-912d-a8ee4e3d3067.png)
# Types of changes
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)
# Checklist:
 - [x] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [x] I have read the CONTRIBUTING document.