### PR TITLE
Fix the NPC movement in blocked foreground tiles.

### DIFF
--- a/server/core/npc.js
+++ b/server/core/npc.js
@@ -70,37 +70,37 @@ class NPC {
           // What tile will they be stepping on?
           const tile = {
             background: UI.getFutureTileID(world.map.background, npc.x, npc.y, going),
-            foreground: UI.getFutureTileID(world.map.foreground, npc.x, npc.y, going),
+            foreground: UI.getFutureTileID(world.map.foreground, npc.x, npc.y, going) - 252,
           };
+
+          // Can the NPCs walk on that tile in their path?
+          const walkable = {
+            background: UI.tileWalkable(tile.background),
+            foreground: UI.tileWalkable(tile.foreground, 'foreground'),
+          };
+
+          const canWalkThrough = walkable.background && walkable.foreground;
 
           switch (going) {
             default:
             case 'up':
-              if ((npc.y - 1) >= (npc.spawn.y - npc.range)) {
-                if (UI.tileWalkable(tile.background) && UI.tileWalkable(tile.foreground)) {
-                  npc.y -= 1;
-                }
+              if ((npc.y - 1) >= (npc.spawn.y - npc.range) && canWalkThrough) {
+                npc.y -= 1;
               }
               break;
             case 'down':
-              if ((npc.y + 1) <= (npc.spawn.y + npc.range)) {
-                if (UI.tileWalkable(tile.background) && UI.tileWalkable(tile.foreground)) {
-                  npc.y += 1;
-                }
+              if ((npc.y + 1) <= (npc.spawn.y + npc.range) && canWalkThrough) {
+                npc.y += 1;
               }
               break;
             case 'left':
-              if ((npc.x - 1) >= (npc.spawn.x - npc.range)) {
-                if (UI.tileWalkable(tile.background) && UI.tileWalkable(tile.foreground)) {
-                  npc.x -= 1;
-                }
+              if ((npc.x - 1) >= (npc.spawn.x - npc.range) && canWalkThrough) {
+                npc.x -= 1;
               }
               break;
             case 'right':
-              if ((npc.x + 1) <= (npc.spawn.x + npc.range)) {
-                if (UI.tileWalkable(tile.background) && UI.tileWalkable(tile.foreground)) {
-                  npc.x += 1;
-                }
+              if ((npc.x + 1) <= (npc.spawn.x + npc.range) && canWalkThrough) {
+                npc.x += 1;
               }
               break;
           }

--- a/server/core/player.js
+++ b/server/core/player.js
@@ -215,9 +215,6 @@ class Player {
       headers: { Authorization: `Bearer ${this.token}` },
     };
 
-    console.log(url);
-    console.log(reqConfig);
-
     let getPlayer = world.players
       .find(p => p.token === this.token);
 

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,6 @@ if ('WebSocket' in window) {
   const port = hostname.includes('localhost') ? ':9000' : '';
   const base = tls === 'ws' ? `localhost${port}` : (`${hostname}${port}/ws`);
   const connectionURI = `${tls}://${base}`;
-  console.log(`[Websocket] Connecting to: ${connectionURI}`);
   window.ws = new WebSocket(connectionURI);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When an NPC moves, it will look in the correct `array` in the `tileWalkable` method (Should probably change this.) in the `UI` class by applying the parameter `layer` to the `foreground` so it knows which `array` to look from.

## Related Issue
 This closes #25 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

An NPC should not be allowed to talk into blocked tiles in the foreground layer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
