### PR TITLE
Added cancel button functionality to Login Screen

### DIFF
--- a/src/Navarra.vue
+++ b/src/Navarra.vue
@@ -94,6 +94,8 @@ export default {
 
     // On logout, let's do a few things...
     bus.$on('player:logout', this.logout);
+
+    bus.$on('go:main', this.cancelLogin);
   },
   data() {
     return {
@@ -111,6 +113,15 @@ export default {
       this.screen = 'login';
       this.game = false;
     },
+
+    /**
+      * Cancel login
+      */
+
+    cancelLogin() {
+      this.screen = 'main';
+    },
+
     /**
      * Player movement, do something
      */

--- a/src/components/ui/Login.vue
+++ b/src/components/ui/Login.vue
@@ -20,9 +20,9 @@ import Socket from '../../core/utilities/socket';
 
 export default {
   methods: {
+    //Cancels login on button click
     cancel() {
       bus.$emit('go:main');
-      // Does nothing -- atm.
     },
     // Send login request to server.
     login() {

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue';
 import Navarra from './Navarra';
-import bus from './core/utilities/bus';
 
 Vue.config.productionTip = false;
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue';
 import Navarra from './Navarra';
+import bus from './core/utilities/bus';
 
 Vue.config.productionTip = false;
 


### PR DESCRIPTION
## Description

Added a cancelLogin method to the Navarra.vue file.

Using the pre-existing event bus in the login.vue file, I put an event listener in the 'created' hook of the Navarra.vue lifecycle. It calls on the cancelLogin method, which sets the screen to 'main'.

## Related Issue

[Issue #28 Cancel button on login screen should back to main screen](https://github.com/Navarra/game/issues/28)

## Motivation and Context
The user needs to be able to return to the main screen if, let's say, they clicked on the login button by accident and need to register. Refreshing the page is never a good solution.

## How Has This Been Tested?

- Went to login screen
- Clicked 'cancel'
- Was returned to main screen

Also logged in, logged out, and clicked 'cancel' again. Did not see any exceptions thrown in Chrome or Firefox consoles.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
